### PR TITLE
Syncing searches divergent branches

### DIFF
--- a/core/bittorrent_trackers.go
+++ b/core/bittorrent_trackers.go
@@ -11,7 +11,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -81,7 +81,7 @@ func addPeerToSwarm(peerID string, infoHash string, port int) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/core/nakamoto/netpeer_server.go
+++ b/core/nakamoto/netpeer_server.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"sort"
@@ -88,7 +88,7 @@ func (s *PeerServer) inboxHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request body", http.StatusBadRequest)
 		return
@@ -168,7 +168,7 @@ func SendMessageToPeer(peerUrl string, message any, log *log.Logger) ([]byte, er
 	defer resp.Body.Close()
 
 	// Read response.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %v", err)
 	}

--- a/core/nakamoto/node_test.go
+++ b/core/nakamoto/node_test.go
@@ -3,7 +3,6 @@ package nakamoto
 import (
 	"encoding/binary"
 	"encoding/json"
-	"math"
 	"testing"
 	"time"
 
@@ -218,108 +217,6 @@ func TestNodeSyncMissingBlocks(t *testing.T) {
 
 	// Check that the tips are the same.
 	assert.Equal(tip1, tip2)
-}
-
-// One part of the block sync algorithm is determining the common ancestor of two chains:
-//
-//	Chain 1: the chain we have on our local node.
-//	Chain 2: the chain of a remote peer who has a more recent tip.
-//
-// We determine the common ancestor in order to download the most minimal set of block headers required to sync to the latest tip.
-// There are a few approaches to this:
-// - naive approach: download all headers from the tip to the remote peer's genesis block, and then compare the headers to find the common ancestor. This is O(N) where N is the length of the longest chain.
-// - naive approach 2: send the peer the block we have at (height - 6), which is according to Nakamoto's calculations, "probabilistically final" and unlikely to be reorg-ed. Ask them if they have this block, and if so, sync the remaining 6 blocks. This fails when there is ongoing volatile reorgs, as well as doesn't work for a full sync.
-// - slightly less naive approach: send the peer "checkpoints" at a regular interval. So for the full list of block hashes, we send H/I where I is the interval size, and use this to sync. This is O(H/I).
-// - slightly slightly less naive approach: send the peer a list of "checkpoints" at exponentially decreasing intervals. This is smart since the finality of a block increases exponentially with the number of confirmations. This is O(H/log(H)).
-// - the most efficient approach. Interactively binary search with the node. At each step of the binary search, we split their view of the chain hash list in half, and ask them if they have the block at the midpoint.
-//
-// Let me explain the binary search.
-// <------------------------>   our view
-// <------------------------> their view
-// n=1
-// <------------|-----------> their view
-// <------------------|-----> their view
-// <---------------|--------> their view
-// At each iteration we ask: do you have a block at height/2 with this hash?
-// - if the answer is yes, we move to the right half.
-// - if the answer is no, we move to the left half.
-// We continue until the length of our search space = 1.
-//
-// Now for some modelling.
-// Finding the common ancestor is O(log N). Each message is (blockhash [32]byte, height uint64). Message size is 40 bytes.
-// Total networking cost is O(40 * log N), bitcoin's chain height is 850585, O(40 * log 850585) = O(40 * 20) = O(800) bytes.
-// Less than 1KB of data to find common ancestor.
-func TestInteractiveBinarySearchFindCommonAncestor(t *testing.T) {
-	local_chainhashes := [][32]byte{}
-	remote_chainhashes := [][32]byte{}
-
-	// Populate blockhashes for test.
-	for i := 0; i < 100; i++ {
-		local_chainhashes = append(local_chainhashes, uint64To32ByteArray(uint64(i)))
-		remote_chainhashes = append(remote_chainhashes, uint64To32ByteArray(uint64(i)))
-	}
-	// Set remote to branch at block height 90.
-	for i := 90; i < 100; i++ {
-		remote_chainhashes[i] = uint64To32ByteArray(uint64(i + 1000))
-	}
-
-	// Print both for debugging.
-	t.Logf("Local chainhashes:\n")
-	for _, x := range local_chainhashes {
-		t.Logf("%x", x)
-	}
-	t.Logf("\n")
-	t.Logf("Remote chainhashes:\n")
-	for _, x := range remote_chainhashes {
-		t.Logf("%x", x)
-	}
-	t.Logf("\n")
-
-	// Peer method.
-	hasBlockhash := func(blockhash [32]byte) bool {
-		for _, x := range remote_chainhashes {
-			if x == blockhash {
-				return true
-			}
-		}
-		return false
-	}
-
-	//
-	// Find the common ancestor.
-	//
-
-	// This is a classical binary search algorithm.
-	floor := 0
-	ceil := len(local_chainhashes)
-	n_iterations := 0
-
-	for (floor + 1) < ceil {
-		guess_idx := (floor + ceil) / 2
-		guess_value := local_chainhashes[guess_idx]
-
-		t.Logf("Iteration %d: floor=%d, ceil=%d, guess_idx=%d, guess_value=%x", n_iterations, floor, ceil, guess_idx, guess_value)
-		n_iterations += 1
-
-		// Send our tip's blockhash
-		// Peer responds with "SEEN" or "NOT SEEN"
-		// If "SEEN", we move to the right half.
-		// If "NOT SEEN", we move to the left half.
-		if hasBlockhash(guess_value) {
-			// Move to the right half.
-			floor = guess_idx
-		} else {
-			// Move to the left half.
-			ceil = guess_idx
-		}
-	}
-
-	ancestor := local_chainhashes[floor]
-	t.Logf("Common ancestor: %x", ancestor)
-	t.Logf("Found in %d iterations.", n_iterations)
-
-	expectedIterations := math.Ceil(math.Log2(float64(len(local_chainhashes))))
-	t.Logf("Expected iterations: %f", expectedIterations)
 }
 
 func uint64To32ByteArray(num uint64) [32]byte {

--- a/core/nakamoto/sync_test.go
+++ b/core/nakamoto/sync_test.go
@@ -3,6 +3,7 @@ package nakamoto
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -470,7 +471,6 @@ func TestSyncSyncDownloadDataHeaders(t *testing.T) {
 
 func TestSyncSync(t *testing.T) {
 	// After getting the tips, then we need to divide them into work units.
-
 	assert := assert.New(t)
 	peers := setupTestNetwork(t)
 
@@ -530,5 +530,177 @@ func TestSyncSync(t *testing.T) {
 	assertIntEqual(t, 0, downloaded2)
 	downloaded3 := node3.Sync()
 	assertIntEqual(t, 0, downloaded3)
+}
 
+
+// One part of the block sync algorithm is determining the common ancestor of two chains:
+//
+//	Chain 1: the chain we have on our local node.
+//	Chain 2: the chain of a remote peer who has a more recent tip.
+//
+// We determine the common ancestor in order to download the most minimal set of block headers required to sync to the latest tip.
+// There are a few approaches to this:
+// - naive approach: download all headers from the tip to the remote peer's genesis block, and then compare the headers to find the common ancestor. This is O(N) where N is the length of the longest chain.
+// - naive approach 2: send the peer the block we have at (height - 6), which is according to Nakamoto's calculations, "probabilistically final" and unlikely to be reorg-ed. Ask them if they have this block, and if so, sync the remaining 6 blocks. This fails when there is ongoing volatile reorgs, as well as doesn't work for a full sync.
+// - slightly less naive approach: send the peer "checkpoints" at a regular interval. So for the full list of block hashes, we send H/I where I is the interval size, and use this to sync. This is O(H/I).
+// - slightly slightly less naive approach: send the peer a list of "checkpoints" at exponentially decreasing intervals. This is smart since the finality of a block increases exponentially with the number of confirmations. This is O(H/log(H)).
+// - the most efficient approach. Interactively binary search with the node. At each step of the binary search, we split their view of the chain hash list in half, and ask them if they have the block at the midpoint.
+//
+// Let me explain the binary search.
+// <------------------------>   our view
+// <------------------------> their view
+// n=1
+// <------------|-----------> their view
+// <------------------|-----> their view
+// <---------------|--------> their view
+// At each iteration we ask: do you have a block at height/2 with this hash?
+// - if the answer is yes, we move to the right half.
+// - if the answer is no, we move to the left half.
+// We continue until the length of our search space = 1.
+//
+// Now for some modelling.
+// Finding the common ancestor is O(log N). Each message is (blockhash [32]byte, height uint64). Message size is 40 bytes.
+// Total networking cost is O(40 * log N), bitcoin's chain height is 850585, O(40 * log 850585) = O(40 * 20) = O(800) bytes.
+// Less than 1KB of data to find common ancestor.
+func TestInteractiveBinarySearchFindCommonAncestor(t *testing.T) {
+	local_chainhashes := [][32]byte{}
+	remote_chainhashes := [][32]byte{}
+
+	// Populate blockhashes for test.
+	for i := 0; i < 100; i++ {
+		local_chainhashes = append(local_chainhashes, uint64To32ByteArray(uint64(i)))
+		remote_chainhashes = append(remote_chainhashes, uint64To32ByteArray(uint64(i)))
+	}
+	// Set remote to branch at block height 90.
+	for i := 90; i < 100; i++ {
+		remote_chainhashes[i] = uint64To32ByteArray(uint64(i + 1000))
+	}
+
+	// Print both for debugging.
+	t.Logf("Local chainhashes:\n")
+	for _, x := range local_chainhashes {
+		t.Logf("%x", x)
+	}
+	t.Logf("\n")
+	t.Logf("Remote chainhashes:\n")
+	for _, x := range remote_chainhashes {
+		t.Logf("%x", x)
+	}
+	t.Logf("\n")
+
+	// Peer method.
+	hasBlockhash := func(blockhash [32]byte) bool {
+		for _, x := range remote_chainhashes {
+			if x == blockhash {
+				return true
+			}
+		}
+		return false
+	}
+
+	//
+	// Find the common ancestor.
+	//
+
+	// This is a classical binary search algorithm.
+	floor := 0
+	ceil := len(local_chainhashes)
+	n_iterations := 0
+
+	for (floor + 1) < ceil {
+		guess_idx := (floor + ceil) / 2
+		guess_value := local_chainhashes[guess_idx]
+
+		t.Logf("Iteration %d: floor=%d, ceil=%d, guess_idx=%d, guess_value=%x", n_iterations, floor, ceil, guess_idx, guess_value)
+		n_iterations += 1
+
+		// Send our tip's blockhash
+		// Peer responds with "SEEN" or "NOT SEEN"
+		// If "SEEN", we move to the right half.
+		// If "NOT SEEN", we move to the left half.
+		if hasBlockhash(guess_value) {
+			// Move to the right half.
+			floor = guess_idx
+		} else {
+			// Move to the left half.
+			ceil = guess_idx
+		}
+	}
+
+	ancestor := local_chainhashes[floor]
+	t.Logf("Common ancestor: %x", ancestor)
+	t.Logf("Found in %d iterations.", n_iterations)
+
+	expectedIterations := math.Ceil(math.Log2(float64(len(local_chainhashes))))
+	t.Logf("Expected iterations: %f", expectedIterations)
+}
+
+func TestGetPeerCommonAncestor(t *testing.T) {
+	local_chainhashes := [][32]byte{}
+	remote_chainhashes := [][32]byte{}
+
+	// Populate blockhashes for test.
+	for i := 0; i < 100; i++ {
+		local_chainhashes = append(local_chainhashes, uint64To32ByteArray(uint64(i)))
+		remote_chainhashes = append(remote_chainhashes, uint64To32ByteArray(uint64(i)))
+	}
+	// Set remote to branch at block height 90.
+	for i := 90; i < 100; i++ {
+		remote_chainhashes[i] = uint64To32ByteArray(uint64(i + 1000))
+	}
+
+	// Print both for debugging.
+	t.Logf("Local chainhashes:\n")
+	for _, x := range local_chainhashes {
+		t.Logf("%x", x)
+	}
+	t.Logf("\n")
+	t.Logf("Remote chainhashes:\n")
+	for _, x := range remote_chainhashes {
+		t.Logf("%x", x)
+	}
+	t.Logf("\n")
+
+	// Peer mock.
+	peer1 := NewPeerCore(PeerConfig{ipAddress: "127.0.0.1", port: getRandomPort()})
+	peer2 := NewPeerCore(PeerConfig{ipAddress: "127.0.0.1", port: getRandomPort()})
+
+	go peer1.Start()
+	go peer2.Start()
+
+	// Wait for peers online.
+	waitForPeersOnline([]*PeerCore{peer1, peer2})
+
+	// Bootstrap.
+	peer1.Bootstrap([]string{peer2.GetLocalAddr()})
+
+	peer2.OnHasBlock = func(msg HasBlockMessage) (bool, error) {
+		blockhash := msg.BlockHash
+		for _, x := range remote_chainhashes {
+			if x == blockhash {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	//
+	// Find the common ancestor.
+	//
+
+	remotePeer := peer1.GetPeers()[0]
+	ancestor, n_iterations, err := GetPeerCommonAncestor(peer1, remotePeer, &local_chainhashes)
+	if err != nil {
+		t.Fatalf("Error finding common ancestor: %s", err)
+	}
+	t.Logf("Common ancestor: %x", ancestor)
+	t.Logf("Found in %d iterations.", n_iterations)
+
+	expectedIterations := math.Ceil(math.Log2(float64(len(local_chainhashes))))
+	t.Logf("Expected iterations: %f", expectedIterations)
+
+	// Now we assert the common ancestor.
+	assert := assert.New(t)
+	assert.Equal(local_chainhashes[89], ancestor)
+	assertIntEqual(t, int(expectedIterations), n_iterations)
 }

--- a/core/nakamoto/sync_test.go
+++ b/core/nakamoto/sync_test.go
@@ -806,7 +806,48 @@ func TestSyncRemoteForkBranchRemoteHeavier(t *testing.T) {
 	assertIntEqual(t, 1, heavierTipIndex)
 
 	// The common ancestor should be 
-
-
-
 }
+
+
+func TestSyncGetBestTipFromPeers(t *testing.T) {
+	assert := assert.New(t)
+	peers := setupTestNetwork(t)
+
+	node1 := peers[0]
+	node2 := peers[1]
+	node3 := peers[2]
+
+	// Base case: all tips are the same.
+	bestTip, err := node1.sync_getBestTipFromPeers(node1.Peer.peers)
+	assert.Nil(err)
+	assert.Equal(node1.Dag.FullTip.HashStr(), bestTip.BlockHashStr())
+	assert.Equal(node2.Dag.FullTip.HashStr(), bestTip.BlockHashStr())
+	assert.Equal(node3.Dag.FullTip.HashStr(), bestTip.BlockHashStr())
+
+	// Now we test the case where one peer has a different tip.
+	// Node 1 mines 15 blocks, gossips with node 2
+	node1.Miner.Start(5)
+	node2.Miner.Start(10)
+
+	// node2 should have best tip.
+	bestTip, err = node1.sync_getBestTipFromPeers(node1.Peer.peers)
+	assert.Nil(err)
+	assert.Equal(node2.Dag.FullTip.HashStr(), bestTip.BlockHashStr())
+}
+
+// Sync process:
+// 1. Ask all peers for tips
+// 2. Choose the tip with highest amount of work
+// 3. Find the common ancestor 
+// 4. Sync from this base block
+
+
+// Sync needs to distinguish between two scenarios:
+// 1) live sync: the node is syncing in real-time with the network.
+// 2) cold sync: the node is syncing from a cold start, and needs to download all blocks from the network.
+// what changes in each scenario?
+// - live sync:
+// -- we validate timestamps
+// -- we download just one branch
+// - cold sync
+// -- we download all branches

--- a/core/nakamoto/types.go
+++ b/core/nakamoto/types.go
@@ -96,7 +96,7 @@ type GetBlocksReply struct {
 // has_block
 type HasBlockMessage struct {
 	Type      string `json:"type"` // "have_block"
-	BlockHash string `json:"blockHash"`
+	BlockHash [32]byte `json:"blockHash"`
 }
 
 type HasBlockReply struct {


### PR DESCRIPTION
Right now, in testnet1, the network behaves in a single-producer many-follower consensus mode. While the block DAG correctly determines the heaviest chain from a history of blocks, the sync algorithm does not yet search divergent branch histories (ie forks) from nodes.

Sync is implemented as a greedy search, which starts from a base tip and requests windows of 2048 blocks. The tip we start at is our local headers tip:

https://github.com/tinychainorg/tinychain/blob/main/core/nakamoto/sync.go#L301

As such, the node when it hears of a block on an alternative branch does not download it. And so testnet1 can support proper nakamoto POW branching, once it starts downloading alternative branches too.

The improvement proposed in this PR is to search on divergent branches and download history.

The way this will work:

 1. Interactive binary search to find common ancestor when we hear of a new block we don't know.
   a. First check this remote tip has more accumulated work than the current local tip. 
 2. Perform the search algorithm from this common ancestor.
 3. Download blocks.

